### PR TITLE
Fix container sorting pipeline in check_status script

### DIFF
--- a/check_status.sh
+++ b/check_status.sh
@@ -10,9 +10,11 @@
  # Function to get all container IDs for a service sorted by creation time (oldest first)
  get_all_containers_sorted_by_age() {
      local service=$1
-     docker ps --filter "label=com.docker.compose.service=${service}" -q | xargs docker inspect --format '{{.Created}} {{.Id}}' | sort | awk '{print $2}'
-}
-
+    docker ps --filter "label=com.docker.compose.service=${service}" -q \
+        | xargs -r docker inspect --format '{{.Created}} {{.Id}}' \
+        | sort \
+        | awk '{print $2}'
+    }
 stop_and_remove_container() {
     local container=$1
     docker stop "${container}"


### PR DESCRIPTION
## Summary
- Ensure `check_status.sh` sorts containers correctly by joining the inspect, sort and awk pipeline with proper line continuations
- Prevent errors when no containers match by using `xargs -r`
- Restore executable permission on `check_status.sh`

## Testing
- `shellcheck check_status.sh` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689d94e10d1c8322a1874eb65c2d1fae