### PR TITLE
Run service status checks concurrently

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -2,4 +2,6 @@
 
 docker compose up -d --scale service1=2 --scale service2=2 --no-recreate
 
-./check_status.sh service1 & ./check_status.sh service2
+./check_status.sh service1 &
+./check_status.sh service2 &
+wait


### PR DESCRIPTION
## Summary
- Run service status checks for `service1` and `service2` in parallel within `update.sh`
- Wait for both checks to finish before the script exits

## Testing
- `bash -n update.sh`
- `bash update.sh` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_689d963470108322aa02da53eea9fd3b