### PR TITLE
Fix unsuccessful change step numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The repository includes a Dockerfile and a simple Node.js server for generating 
 6. Updating Services
    Modify the Docker Compose file to update the image with the second healthy image, then run the update script again.
    > ./update.sh
-8. Deploying an Unsuccessful Change
+7. Deploying an Unsuccessful Change
    Update the Docker Compose file with the unhealthy image and run the update script again.
    > ./update.sh
 


### PR DESCRIPTION
## Summary
- Correct README test instructions to sequentially number the final step

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d963342648322a7eaa0b693805482